### PR TITLE
getSlideshowByURL should allow for URLs that contain querystring data

### DIFF
--- a/lib/slideshare.js
+++ b/lib/slideshare.js
@@ -1,6 +1,7 @@
 var rest = require('restler');
 
 var crypto = require('crypto');
+var url = require('url');
 
 function sha1(data) {
     var generator = crypto.createHash('sha1');
@@ -55,17 +56,22 @@ SlideShare.prototype = {
     },
 
     /**
-     * Get a slideshow by it's url
-     * @param {string} url The url of the slideshow
+     * Get a slideshow by its url
+     * @param {string} slideShareUrl The url of the slideshow
      * @return {Object} A slideshow object
      */
-    getSlideshowByURL: function(url, opts, callback) {
+    getSlideshowByURL: function(slideShareUrl, opts, callback) {
         if (typeof opts === "function") {
             callback = opts;
             opts = {};
         }
         opts = opts || {};
-        opts.slideshow_url = url;
+        // The SlideShare API does not take URLs that have querystring parameters so we condense `slideshow_url`
+        // to the minimal URL.
+        // ex: Given `http://www.slideshare.net/username/slideshow?from_search=4` we will request:
+        // `http://www.slideshare.net/username/slideshow`
+        var parsedUrl = url.parse(slideShareUrl);
+        opts.slideshow_url = parsedUrl.protocol + '//' + parsedUrl.host + parsedUrl.pathname;
         this.getSlideshow(opts, callback);
     },
     


### PR DESCRIPTION
This is a fix for those URLs that contain query string data.
All of the URLs on the search results pages contain `?from_search=..` for example.
