### PR TITLE
Use 'query' instead of 'data' for querystring parameters

### DIFF
--- a/lib/slideshare.js
+++ b/lib/slideshare.js
@@ -31,7 +31,7 @@ SlideShare.prototype = {
     coreParams: function() {
         return {
             parser: rest.parsers.xml,
-            data: {
+            query: {
                 api_key: this.api_key,
                 ts: this.timestamp(),
                 hash: this.currentHash()
@@ -78,7 +78,7 @@ SlideShare.prototype = {
     getSlideshow: function(opts, callback) {
         var params = this.coreParams();
         for (var key in opts) {
-            params.data[key] = opts[key];
+            params.query[key] = opts[key];
         }
         rest.get(this.api_url + 'get_slideshow', params).on('complete', function(data) {
             return callback(data);
@@ -93,11 +93,11 @@ SlideShare.prototype = {
      */
     getSlideshowsByTag: function(tag, opts, callback) {
         var params = this.coreParams();
-        params.data.tag = tag;
+        params.query.tag = tag;
         if(opts != null) {
-            params.data.limit = opts.limit;
-            params.data.offset = opts.offset;
-            params.data.detailed = opts.detailed;
+            params.query.limit = opts.limit;
+            params.query.offset = opts.offset;
+            params.query.detailed = opts.detailed;
         }
         rest.get(this.api_url + 'get_slideshows_by_tag', params).on('complete', function(data) {
             return callback(data);
@@ -112,11 +112,11 @@ SlideShare.prototype = {
      */
     getSlideshowsByGroup: function(group_name, opts, callback) {
         var params = this.coreParams();
-        params.data.group_name = group_name;
+        params.query.group_name = group_name;
         if(opts != null) {
-            params.data.limit = opts.limit;
-            params.data.offset = opts.offset;
-            params.data.detailed = opts.detailed;
+            params.query.limit = opts.limit;
+            params.query.offset = opts.offset;
+            params.query.detailed = opts.detailed;
         }
         rest.get(this.api_url + 'get_slideshows_by_group', params).on('complete', function(data) {
             return callback(data);
@@ -131,16 +131,16 @@ SlideShare.prototype = {
      */
     getSlideshowsByUser: function(username_for, opts, callback) {
         var params = this.coreParams();
-        params.data.username_for = username_for;
+        params.query.username_for = username_for;
         if(opts != null) {
             if(opts.username != undefined && opts.password != undefined) {
-                params.data.username = opts.username;
-                params.data.password = opts.password;
+                params.query.username = opts.username;
+                params.query.password = opts.password;
             }
-            params.data.limit = opts.limit;
-            params.data.offset = opts.offset;
-            params.data.detailed = opts.detailed;
-            params.data.get_unconverted = opts.get_unconverted;
+            params.query.limit = opts.limit;
+            params.query.offset = opts.offset;
+            params.query.detailed = opts.detailed;
+            params.query.get_unconverted = opts.get_unconverted;
         }
         rest.get(this.api_url + 'get_slideshows_by_user', params).on('complete', function(data) {
             return callback(data);
@@ -155,21 +155,21 @@ SlideShare.prototype = {
      */
     searchSlideshows: function(q, opts, callback) {
         var params = this.coreParams();
-        params.data.q = q;
+        params.query.q = q;
         if(opts != null) {
-            params.data.detailed = opts.detailed;
-            params.data.page = opts.page;
-            params.data.items_per_page = opts.items_per_page;
-            params.data.lang = opts.lang;
-            params.data.sort = opts.sort;
-            params.data.upload_date = opts.upload_date;
-            params.data.what = opts.what;
-            params.data.download = opts.download;
-            params.data.fileformat = opts.fileformat;
-            params.data.file_type = opts.file_type;
-            params.data.cc = opts.cc;
-            params.data.cc_adapt = opts.cc_adapt;
-            params.data.cc_commercial = opts.cc_commercial;
+            params.query.detailed = opts.detailed;
+            params.query.page = opts.page;
+            params.query.items_per_page = opts.items_per_page;
+            params.query.lang = opts.lang;
+            params.query.sort = opts.sort;
+            params.query.upload_date = opts.upload_date;
+            params.query.what = opts.what;
+            params.query.download = opts.download;
+            params.query.fileformat = opts.fileformat;
+            params.query.file_type = opts.file_type;
+            params.query.cc = opts.cc;
+            params.query.cc_adapt = opts.cc_adapt;
+            params.query.cc_commercial = opts.cc_commercial;
         }
         rest.get(this.api_url + 'search_slideshows', params).on('complete', function(data) {
             return callback(data);
@@ -184,11 +184,11 @@ SlideShare.prototype = {
      */
     getUserGroups: function(username_for, opts, callback) {
         var params = this.coreParams();
-        params.data.username_for = username_for;
+        params.query.username_for = username_for;
         if(opts != null) {
             if(opts.username != undefined && opts.password != undefined) {
-                params.data.username = opts.username;
-                params.data.password = opts.password;
+                params.query.username = opts.username;
+                params.query.password = opts.password;
             }
         }
         rest.get(this.api_url + 'get_user_groups', params).on('complete', function(data) {
@@ -204,7 +204,7 @@ SlideShare.prototype = {
      */
     getUserFavorites: function(username_for, callback) {
         var params = this.coreParams();
-        params.data.username_for = username_for;
+        params.query.username_for = username_for;
         rest.get(this.api_url + 'get_user_favorites', params).on('complete', function(data) {
             return callback(data);
         });
@@ -219,10 +219,10 @@ SlideShare.prototype = {
      */
     getUserContacts: function(username_for, opts, callback) {
         var params = this.coreParams();
-        params.data.username_for = username_for;
+        params.query.username_for = username_for;
         if(opts != null) {
-            params.data.limit = opts.limit;
-            params.data.offset = opts.offset;
+            params.query.limit = opts.limit;
+            params.query.offset = opts.offset;
         }
         console.log(params);
         rest.get(this.api_url + 'get_user_contacts', params).on('complete', function(data) {
@@ -238,8 +238,8 @@ SlideShare.prototype = {
      */
     getUserTags: function(username, password, callback) {
         var params = this.coreParams();
-        params.data.username = username;
-        params.data.password = password;
+        params.query.username = username;
+        params.query.password = password;
         rest.get(this.api_url + 'get_user_tags', params).on('complete', function(data) {
             return callback(data);
         });


### PR DESCRIPTION
I think SlideShare changed their API to not allow data in the body of GET requests -- a couple unit tests of ours started failing. This PR switches to using the `query` object instead of `data` so that restler will stuff the data into the querystring instead of the request body.
